### PR TITLE
adding stamp noise std in cosmos dataset

### DIFF
--- a/galsim_jax/datasets/cosmos.py
+++ b/galsim_jax/datasets/cosmos.py
@@ -3,51 +3,42 @@ import tensorflow_datasets as tfds
 import numpy as np
 import galsim as gs
 
-from tensorflow_datasets.core.utils import gcs_utils
-
-# disable internet connection
-gcs_utils.gcs_dataset_info_files = lambda *args, **kwargs: None
-gcs_utils.is_dataset_on_gcs = lambda *args, **kwargs: False
-
 _CITATION = """
 """
 
 _DESCRIPTION = """
 """
 
-
 class CosmosConfig(tfds.core.BuilderConfig):
-    """BuilderConfig for Cosmos."""
+  """BuilderConfig for Cosmos."""
 
-    def __init__(self, *, sample="25.2", stamp_size=128, pixel_scale=0.03, **kwargs):
-        """BuilderConfig for Cosmos.
-        Args:
-          sample: which Cosmos sample to use, "25.2".
-          stamp_size: image stamp size in pixels.
-          pixel_scale: pixel scale of stamps in arcsec.
-          **kwargs: keyword arguments forwarded to super.
-        """
-        v1 = tfds.core.Version("0.0.1")
-        super(CosmosConfig, self).__init__(
-            description=(
-                "Cosmos stamps from %s sample in %d x %d resolution, %.2f arcsec/pixel."
-                % (sample, stamp_size, stamp_size, pixel_scale)
-            ),
-            version=v1,
-            **kwargs
-        )
-        self.stamp_size = stamp_size
-        self.pixel_scale = pixel_scale
-        self.sample = sample
-
+  def __init__(self, *, sample="25.2", stamp_size=128, pixel_scale=0.03, **kwargs):
+    """BuilderConfig for Cosmos.
+    Args:
+      sample: which Cosmos sample to use, "25.2".
+      stamp_size: image stamp size in pixels.
+      pixel_scale: pixel scale of stamps in arcsec.
+      **kwargs: keyword arguments forwarded to super.
+    """
+    v1 = tfds.core.Version("0.0.1")
+    super(CosmosConfig, self).__init__(
+        description=("Cosmos stamps from %s sample in %d x %d resolution, %.2f arcsec/pixel." %
+                      (sample, stamp_size, stamp_size, pixel_scale)),
+        version=v1,
+        **kwargs)
+    self.stamp_size = stamp_size
+    self.pixel_scale = pixel_scale
+    self.sample = sample
 
 class Cosmos(tfds.core.GeneratorBasedBuilder):
-    """DatasetBuilder for Cosmos dataset."""
+  """DatasetBuilder for Cosmos dataset."""
 
-    VERSION = tfds.core.Version("0.0.1")
-    RELEASE_NOTES = {
-        "0.0.1": "Initial release.",
-    }
+  VERSION = tfds.core.Version('0.0.1')
+  RELEASE_NOTES = {
+      '0.0.1': 'Initial release.',
+  }
+  
+  BUILDER_CONFIGS = [CosmosConfig(name="25.2", sample="25.2")]
 
   def _info(self) -> tfds.core.DatasetInfo:
     """Returns the dataset metadata."""
@@ -71,57 +62,29 @@ class Cosmos(tfds.core.GeneratorBasedBuilder):
         citation=_CITATION,
     )
 
-    def _info(self) -> tfds.core.DatasetInfo:
-        """Returns the dataset metadata."""
-        # TODO(kappatng): Specifies the tfds.core.DatasetInfo object
-        return tfds.core.DatasetInfo(
-            builder=self,
-            description=_DESCRIPTION,
-            features=tfds.features.FeaturesDict(
-                {
-                    # These are the features of your dataset like images, labels ...
-                    "image": tfds.features.Tensor(
-                        shape=[
-                            self.builder_config.stamp_size,
-                            self.builder_config.stamp_size,
-                        ],
-                        dtype=tf.float32,
-                    ),
-                    "psf": tfds.features.Tensor(
-                        shape=[
-                            self.builder_config.stamp_size,
-                            self.builder_config.stamp_size,
-                        ],
-                        dtype=tf.float32,
-                    ),
-                }
-            ),
-            # If there's a common (input, target) tuple from the
-            # features, specify them here. They'll be used if
-            # `as_supervised=True` in `builder.as_dataset`.
-            supervised_keys=("image", "image"),
-            homepage="https://dataset-homepage/",
-            citation=_CITATION,
-        )
+  def _split_generators(self, dl_manager: tfds.download.DownloadManager):
+    """Returns SplitGenerators."""
+    return [
+        tfds.core.SplitGenerator(
+            name=tfds.Split.TRAIN,
+            gen_kwargs={
+            "offset": 0,
+            "size": 40000,
+            },),
+        tfds.core.SplitGenerator(
+            name=tfds.Split.TEST,
+            gen_kwargs={
+            "offset": 40000,
+            "size": 10000,
+            },
+        ),
+    ]
 
-    def _split_generators(self, dl_manager: tfds.download.DownloadManager):
-        """Returns SplitGenerators."""
-        return [
-            tfds.core.SplitGenerator(
-                name=tfds.Split.TRAIN,
-                gen_kwargs={
-                    "offset": 0,
-                    "size": 40000,
-                },
-            ),
-            tfds.core.SplitGenerator(
-                name=tfds.Split.TEST,
-                gen_kwargs={
-                    "offset": 40000,
-                    "size": 10000,
-                },
-            ),
-        ]
+  def _generate_examples(self, offset, size):
+    """Yields examples."""
+    # Loads the galsim COSMOS catalog
+    cat = gs.COSMOSCatalog(sample=self.builder_config.sample)
+    ngal = size 
 
     for i in range(ngal):
       gal = cat.makeGalaxy(i+offset)

--- a/galsim_jax/datasets/cosmos.py
+++ b/galsim_jax/datasets/cosmos.py
@@ -3,6 +3,12 @@ import tensorflow_datasets as tfds
 import numpy as np
 import galsim as gs
 
+from tensorflow_datasets.core.utils import gcs_utils
+
+# disable internet connection
+gcs_utils.gcs_dataset_info_files = lambda *args, **kwargs: None
+gcs_utils.is_dataset_on_gcs = lambda *args, **kwargs: False
+
 _CITATION = """
 """
 

--- a/galsim_jax/datasets/cosmos.py
+++ b/galsim_jax/datasets/cosmos.py
@@ -16,100 +16,100 @@ _DESCRIPTION = """
 """
 
 class CosmosConfig(tfds.core.BuilderConfig):
-  """BuilderConfig for Cosmos."""
+    """BuilderConfig for Cosmos."""
 
-  def __init__(self, *, sample="25.2", stamp_size=128, pixel_scale=0.03, **kwargs):
-    """BuilderConfig for Cosmos.
-    Args:
-      sample: which Cosmos sample to use, "25.2".
-      stamp_size: image stamp size in pixels.
-      pixel_scale: pixel scale of stamps in arcsec.
-      **kwargs: keyword arguments forwarded to super.
-    """
-    v1 = tfds.core.Version("0.0.1")
-    super(CosmosConfig, self).__init__(
-        description=("Cosmos stamps from %s sample in %d x %d resolution, %.2f arcsec/pixel." %
-                      (sample, stamp_size, stamp_size, pixel_scale)),
-        version=v1,
-        **kwargs)
-    self.stamp_size = stamp_size
-    self.pixel_scale = pixel_scale
-    self.sample = sample
+    def __init__(self, *, sample="25.2", stamp_size=128, pixel_scale=0.03, **kwargs):
+        """BuilderConfig for Cosmos.
+        Args:
+        sample: which Cosmos sample to use, "25.2".
+        stamp_size: image stamp size in pixels.
+        pixel_scale: pixel scale of stamps in arcsec.
+        **kwargs: keyword arguments forwarded to super.
+        """
+        v1 = tfds.core.Version("0.0.1")
+        super(CosmosConfig, self).__init__(
+            description=("Cosmos stamps from %s sample in %d x %d resolution, %.2f arcsec/pixel." %
+                        (sample, stamp_size, stamp_size, pixel_scale)),
+            version=v1,
+            **kwargs)
+        self.stamp_size = stamp_size
+        self.pixel_scale = pixel_scale
+        self.sample = sample
 
 class Cosmos(tfds.core.GeneratorBasedBuilder):
-  """DatasetBuilder for Cosmos dataset."""
+    """DatasetBuilder for Cosmos dataset."""
 
-  VERSION = tfds.core.Version('0.0.1')
-  RELEASE_NOTES = {
-      '0.0.1': 'Initial release.',
-  }
-  
-  BUILDER_CONFIGS = [CosmosConfig(name="25.2", sample="25.2")]
+    VERSION = tfds.core.Version('0.0.1')
+    RELEASE_NOTES = {
+        '0.0.1': 'Initial release.',
+    }
+    
+    BUILDER_CONFIGS = [CosmosConfig(name="25.2", sample="25.2")]
 
-  def _info(self) -> tfds.core.DatasetInfo:
-    """Returns the dataset metadata."""
-    # TODO(kappatng): Specifies the tfds.core.DatasetInfo object
-    return tfds.core.DatasetInfo(
-        builder=self,
-        description=_DESCRIPTION,
-        features=tfds.features.FeaturesDict({
-            # These are the features of your dataset like images, labels ...
-            "image": tfds.features.Tensor(shape=[self.builder_config.stamp_size,
-                                                 self.builder_config.stamp_size], dtype=np.float32),
-            "psf":   tfds.features.Tensor(shape=[self.builder_config.stamp_size,
-                                                 self.builder_config.stamp_size], dtype=np.float32),
-            "noise_std": tfds.features.Scalar(dtype=np.float32)
-	}),
-        # If there's a common (input, target) tuple from the
-        # features, specify them here. They'll be used if
-        # `as_supervised=True` in `builder.as_dataset`.
-        supervised_keys=("image", "image"),
-        homepage='https://dataset-homepage/',
-        citation=_CITATION,
-    )
+    def _info(self) -> tfds.core.DatasetInfo:
+        """Returns the dataset metadata."""
+        # TODO(kappatng): Specifies the tfds.core.DatasetInfo object
+        return tfds.core.DatasetInfo(
+            builder=self,
+            description=_DESCRIPTION,
+            features=tfds.features.FeaturesDict({
+                # These are the features of your dataset like images, labels ...
+                "image": tfds.features.Tensor(shape=[self.builder_config.stamp_size,
+                                                    self.builder_config.stamp_size], dtype=np.float32),
+                "psf":   tfds.features.Tensor(shape=[self.builder_config.stamp_size,
+                                                    self.builder_config.stamp_size], dtype=np.float32),
+                "noise_std": tfds.features.Scalar(dtype=np.float32)
+        }),
+            # If there's a common (input, target) tuple from the
+            # features, specify them here. They'll be used if
+            # `as_supervised=True` in `builder.as_dataset`.
+            supervised_keys=("image", "image"),
+            homepage='https://dataset-homepage/',
+            citation=_CITATION,
+        )
 
-  def _split_generators(self, dl_manager: tfds.download.DownloadManager):
-    """Returns SplitGenerators."""
-    return [
-        tfds.core.SplitGenerator(
-            name=tfds.Split.TRAIN,
-            gen_kwargs={
-            "offset": 0,
-            "size": 40000,
-            },),
-        tfds.core.SplitGenerator(
-            name=tfds.Split.TEST,
-            gen_kwargs={
-            "offset": 40000,
-            "size": 10000,
-            },
-        ),
-    ]
+    def _split_generators(self, dl_manager: tfds.download.DownloadManager):
+        """Returns SplitGenerators."""
+        return [
+            tfds.core.SplitGenerator(
+                name=tfds.Split.TRAIN,
+                gen_kwargs={
+                "offset": 0,
+                "size": 40000,
+                },),
+            tfds.core.SplitGenerator(
+                name=tfds.Split.TEST,
+                gen_kwargs={
+                "offset": 40000,
+                "size": 10000,
+                },
+            ),
+        ]
 
-  def _generate_examples(self, offset, size):
-    """Yields examples."""
-    # Loads the galsim COSMOS catalog
-    cat = gs.COSMOSCatalog(sample=self.builder_config.sample)
-    ngal = size 
+    def _generate_examples(self, offset, size):
+        """Yields examples."""
+        # Loads the galsim COSMOS catalog
+        cat = gs.COSMOSCatalog(sample=self.builder_config.sample)
+        ngal = size 
 
-    for i in range(ngal):
-      gal = cat.makeGalaxy(i+offset)
-      cosmos_gal = gs.Convolve(gal, gal.original_psf)
-      
-      cosmos_stamp = cosmos_gal.drawImage(nx=self.builder_config.stamp_size, 
-                                          ny=self.builder_config.stamp_size, 
-                                          scale=self.builder_config.pixel_scale, 
-                                          method='no_pixel').array.astype('float32')
-                                          
-      cosmos_psf_stamp = gal.original_psf.drawImage(nx=self.builder_config.stamp_size, 
-                                          ny=self.builder_config.stamp_size, 
-                                          scale=self.builder_config.pixel_scale,
-                                          method='no_pixel').array.astype('float32')
+        for i in range(ngal):
+        gal = cat.makeGalaxy(i+offset)
+        cosmos_gal = gs.Convolve(gal, gal.original_psf)
+        
+        cosmos_stamp = cosmos_gal.drawImage(nx=self.builder_config.stamp_size, 
+                                            ny=self.builder_config.stamp_size, 
+                                            scale=self.builder_config.pixel_scale, 
+                                            method='no_pixel').array.astype('float32')
+                                            
+        cosmos_psf_stamp = gal.original_psf.drawImage(nx=self.builder_config.stamp_size, 
+                                            ny=self.builder_config.stamp_size, 
+                                            scale=self.builder_config.pixel_scale,
+                                            method='no_pixel').array.astype('float32')
 
-      noise_std = np.sqrt(cosmos_gal.noise.getVariance())
+        noise_std = np.sqrt(cosmos_gal.noise.getVariance())
 
-      yield '%d'%i, {
-        "image": cosmos_stamp, 
-        "psf":cosmos_psf_stamp,
-        "noise_std": noise_std
-      }
+        yield '%d'%i, {
+            "image": cosmos_stamp, 
+            "psf":cosmos_psf_stamp,
+            "noise_std": noise_std
+        }

--- a/galsim_jax/datasets/cosmos.py
+++ b/galsim_jax/datasets/cosmos.py
@@ -1,6 +1,5 @@
 """ TensorFlow Dataset of COSMOS images. """
 import tensorflow_datasets as tfds
-import tensorflow as tf
 import numpy as np
 import galsim as gs
 
@@ -50,9 +49,10 @@ class Cosmos(tfds.core.GeneratorBasedBuilder):
         features=tfds.features.FeaturesDict({
             # These are the features of your dataset like images, labels ...
             "image": tfds.features.Tensor(shape=[self.builder_config.stamp_size,
-                                                 self.builder_config.stamp_size], dtype=tf.float32),
+                                                 self.builder_config.stamp_size], dtype=np.float32),
             "psf":   tfds.features.Tensor(shape=[self.builder_config.stamp_size,
-                                                 self.builder_config.stamp_size], dtype=tf.float32)
+                                                 self.builder_config.stamp_size], dtype=np.float32),
+            "noise_std": tfds.features.Scalar(dtype=np.float32)
 	}),
         # If there's a common (input, target) tuple from the
         # features, specify them here. They'll be used if
@@ -99,4 +99,11 @@ class Cosmos(tfds.core.GeneratorBasedBuilder):
                                           ny=self.builder_config.stamp_size, 
                                           scale=self.builder_config.pixel_scale,
                                           method='no_pixel').array.astype('float32')
-      yield '%d'%i, {"image": cosmos_stamp, "psf":cosmos_psf_stamp}
+
+      noise_std = np.sqrt(cosmos_gal.noise.getVariance())
+
+      yield '%d'%i, {
+        "image": cosmos_stamp, 
+        "psf":cosmos_psf_stamp,
+        "noise_std": noise_std
+      }


### PR DESCRIPTION
Hi @JonnyyTorres ,

This PR will add an entry in the cosmos dataset containing the noise standard deviation of each postage stamp, as `batch["noise_std"]`.

Here is an example of how it was computed
```python
gal = cat.makeGalaxy(200)
psf = gal.original_psf
stamp = gs.Convolve(gal, gal.original_psf)

print(np.sqrt(stamp.noise.getVariance()))
# >>> 0.0022283904455643877
```

This parameter will replace the `scale_diag` argument of the likelihood of our model
https://github.com/JonnyyTorres/Galsim_JAX/blob/b1c4cc3b61657aa97647dd5e863c920cb8608d4d/VAE_SD_C.py#L164