### PR TITLE
New convolution

### DIFF
--- a/VAE_SD_C.py
+++ b/VAE_SD_C.py
@@ -44,8 +44,8 @@ from absl import flags
 flags.DEFINE_string("dataset", "Cosmos/25.2", "Suite of simulations to learn from")
 # flags.DEFINE_string("output_dir", "./weights/gp-sn1v5", "Folder where to store model.")
 flags.DEFINE_integer("batch_size", 64, "Size of the batch to train on.")
-flags.DEFINE_float("learning_rate", 1e-4, "Learning rate for the optimizer.")
-flags.DEFINE_integer("training_steps", 50000, "Number of training steps to run.")
+flags.DEFINE_float("learning_rate", 1e-3, "Learning rate for the optimizer.")
+flags.DEFINE_integer("training_steps", 125000, "Number of training steps to run.")
 # flags.DEFINE_string("train_split", "90%", "How much of the training set to use.")
 # flags.DEFINE_boolean('prob_output', True, 'The encoder has or not a probabilistic output')
 flags.DEFINE_float("reg_value", 1e-6, "Regularization value of the KL Divergence.")
@@ -306,7 +306,7 @@ def main(_):
             )
 
     # Loading checkpoint for the best step
-    params = load_checkpoint("checkpoint.msgpack", params)
+    #params = load_checkpoint("checkpoint.msgpack", params)
 
     # Obtaining the step with the lowest loss value
     loss_min = min(losses)
@@ -389,7 +389,7 @@ def main(_):
 
     # Taking 16 images as example
     batch = x[:16, ...]
-    psf = psf[:16, ...]
+    kpsf = kpsf[:16, ...]
     std = std[:16, ...]
 
     rng, rng_1 = random.split(rng)

--- a/galsim_jax/convolution.py
+++ b/galsim_jax/convolution.py
@@ -30,3 +30,128 @@ def convolve(image, psf, return_Fourier=False):
         return im_conv
     else:
         return jnp.fft.ifftshift(jnp.fft.ifft2(jnp.fft.ifftshift(im_conv)).real)
+
+def k_wrapping(kimage, wrap_factor=1):
+    """Wraps kspace image of a real image to decrease its resolution by specified
+    factor
+    
+    Args:
+    kimage: `Tensor`, image in Fourier space of shape [batch_size, nkx, nky]
+    wrap_factor: `float`, wrap factor
+    
+    Returns:
+    kimage: `Tensor`, kspace image with descreased resolution by wrap factor
+    """
+    
+    Nkx, Nky = kimage.shape
+
+    # First wrap around the non hermitian dimension
+    rkimage = kimage + jnp.roll(kimage, shift=Nkx // wrap_factor, axis=0)
+
+    # Now take care of the hermitian part
+    revrkimage = jnp.flip(jnp.conjugate((jnp.flip(rkimage, axis=1))), 0)
+
+    # These masks take care of the special case of the 0th frequency
+    mask = np.ones([Nkx, Nky])
+    mask[0, :] = 0
+    mask[Nkx//wrap_factor-1, :] = 0
+    rkimage2 = rkimage + revrkimage*mask
+    mask = np.zeros([Nkx, Nky])
+    mask[Nkx//wrap_factor-1,:] = 1
+    rkimage2 = rkimage2 + jnp.roll(revrkimage, shift=-1, axis=0) * mask
+
+    kimage = rkimage2[:Nkx//wrap_factor, :(Nky-1)//wrap_factor+1]
+
+    return kimage
+
+def kconvolve(kimage, kpsf,
+             zero_padding_factor=1,
+             interp_factor=1):
+    """
+    Convolution of provided k-space images and psf tensor.
+    
+    Careful! This function doesn't remove zero padding.
+    Careful! When using a kimage and kpsf from GalSim,
+           one needs to apply an fftshift at the output.
+    
+    This function assumes that the k-space tensors are already prodided with the
+    stepk and maxk corresponding to the specified interpolation and zero padding
+    factors.
+    
+    Args:
+        kimages: `Tensor`, image in Fourier space of shape [batch_size, nkx, nky]
+        kpsf: `Tensor`, PSF image in Fourier space
+        zero_padding_factor: `int`, amount of zero padding
+        interp_factor: `int`, interpolation factor
+    
+    Returns:
+        `Tensor`, real image after convolution
+    """
+
+    Nkx, Nky = kimage.shape
+    Nx = Nkx // zero_padding_factor // interp_factor
+
+    # Perform k-space convolution
+    imk = kimage * kpsf
+
+    # Apply frequency wrapping to reach target image resolution
+    if interp_factor > 1:
+        imk = k_wrapping(imk, interp_factor)
+
+    # Perform inverse Fourier Transform
+    conv_images = jnp.fft.irfft2(imk)
+
+    return conv_images
+
+def convolve_kpsf(image, kpsf,
+             x_interpolant=jax.image.ResizeMethod.LANCZOS5,
+             zero_padding_factor=1,
+             interp_factor=1,
+             ):
+    """
+    Convolution of input images with provided k-space psf tensor.
+    
+    This function assumes that the k-space PSF is already prodided with the
+    stepk and maxk corresponding to the specified interpolation and zero padding
+    factors.
+    
+    Args:
+        images: `Tensor`, input image in real space of shape [nkx, nky]
+        x_interpolant: `string`, argument returned by `tf.image.ResizeMethod.BICUBIC` 
+          or `tf.image.ResizeMethod.BILINEAR` for instance
+        zero_padding_factor: `int`, amount of zero padding
+        interp_factor: `int`, interpolation factor
+    
+    Returns:
+        `Tensor`, real image after convolution
+    """
+    Nx, Ny = image.shape
+
+    assert Nx == Ny
+    assert Nx % 2 == 0
+
+    # First, we interpolate the image on a finer grid
+    if interp_factor > 1:
+        im = jax.image.resize(image,
+                              [Nx*interp_factor,
+                              Ny*interp_factor],
+                              method = x_interpolant)
+        # since we lower the resolution of the image, we also scale the flux
+        # accordingly
+        image = im / interp_factor**2
+
+    # Second, we pad as necessary
+    #im = image
+    pad_size = Nx * interp_factor * (zero_padding_factor - 1) // 2 
+    im = jnp.pad(image, pad_size)
+
+    # Compute DFT
+    imk = jnp.fft.rfft2(im)
+                 
+    # Performing k space convolution
+    imconv = kconvolve(imk, kpsf,
+                       zero_padding_factor=zero_padding_factor,
+                       interp_factor=interp_factor)
+
+    a, b = imconv.shape
+    return imconv[a//2-Nx//2:a//2+Nx//2, b//2-Nx//2:b//2+Nx//2]

--- a/galsim_jax/datasets/cosmos.py
+++ b/galsim_jax/datasets/cosmos.py
@@ -2,6 +2,9 @@
 import tensorflow_datasets as tfds
 import numpy as np
 import galsim as gs
+from galsim.bounds import _BoundsI
+
+import tensorflow as tf
 
 from tensorflow_datasets.core.utils import gcs_utils
 
@@ -67,14 +70,21 @@ class Cosmos(tfds.core.GeneratorBasedBuilder):
                         ],
                         dtype=np.float32,
                     ),
-                    "psf": tfds.features.Tensor(
+                    "kpsf_real": tfds.features.Tensor(
                         shape=[
                             self.builder_config.stamp_size,
-                            self.builder_config.stamp_size,
+                            self.builder_config.stamp_size//2+1,
                         ],
                         dtype=np.float32,
                     ),
-                    "noise_std": tfds.features.Scalar(dtype=np.float32),
+                    "kpsf_imag": tfds.features.Tensor(
+                        shape=[
+                            self.builder_config.stamp_size,
+                            self.builder_config.stamp_size//2+1,
+                        ],
+                        dtype=np.float32,
+                    ),
+                    # "noise_std": tfds.features.Scalar(dtype=tf.float32),
                 }
             ),
             # If there's a common (input, target) tuple from the
@@ -92,14 +102,14 @@ class Cosmos(tfds.core.GeneratorBasedBuilder):
                 name=tfds.Split.TRAIN,
                 gen_kwargs={
                     "offset": 0,
-                    "size": 40000,
+                    "size": 4000,
                 },
             ),
             tfds.core.SplitGenerator(
                 name=tfds.Split.TEST,
                 gen_kwargs={
-                    "offset": 40000,
-                    "size": 10000,
+                    "offset": 4000,
+                    "size": 1000,
                 },
             ),
         ]
@@ -121,17 +131,24 @@ class Cosmos(tfds.core.GeneratorBasedBuilder):
                 method="no_pixel",
             ).array.astype("float32")
 
-            cosmos_psf_stamp = gal.original_psf.drawImage(
-                nx=self.builder_config.stamp_size,
-                ny=self.builder_config.stamp_size,
-                scale=self.builder_config.pixel_scale,
-                method="no_pixel",
-            ).array.astype("float32")
+            interp_factor = 1
+            padding_factor = 1
+            Nk = self.builder_config.stamp_size * interp_factor * padding_factor
+            bounds = _BoundsI(0, Nk//2, -Nk//2, Nk//2-1)
+            imkpsf = gal.original_psf.drawKImage(bounds=bounds,
+                            scale=2.*np.pi/(self.builder_config.stamp_size*padding_factor*self.builder_config.pixel_scale),
+                            recenter=False)
 
-            noise_std = np.sqrt(cosmos_gal.noise.getVariance())
+            kpsf = np.fft.fftshift(imkpsf.array, 0).astype('complex64')
+            kpsf_real = kpsf.real
+            kpsf_imag = kpsf.imag
+
+
+            # noise_std = np.sqrt(cosmos_gal.noise.getVariance())
 
             yield "%d" % i, {
                 "image": cosmos_stamp,
-                "psf": cosmos_psf_stamp,
-                "noise_std": noise_std,
+                "kpsf_real": kpsf_real,
+                "kpsf_imag": kpsf_imag,
+                # "noise_std": noise_std,
             }

--- a/galsim_jax/datasets/cosmos.py
+++ b/galsim_jax/datasets/cosmos.py
@@ -102,14 +102,14 @@ class Cosmos(tfds.core.GeneratorBasedBuilder):
                 name=tfds.Split.TRAIN,
                 gen_kwargs={
                     "offset": 0,
-                    "size": 4000,
+                    "size": 40000,
                 },
             ),
             tfds.core.SplitGenerator(
                 name=tfds.Split.TEST,
                 gen_kwargs={
-                    "offset": 4000,
-                    "size": 1000,
+                    "offset": 40000,
+                    "size": 10000,
                 },
             ),
         ]


### PR DESCRIPTION
Hi @JonnyyTorres ,

This PR is a attempt to fix the pattern we get in #5 . It adds a new convolution function which takes the PSF in Fourier space as input. I updated the dataset configuration file and the training script `VAE_SD_C.py` to make a few tests. 

I couldn't perform a full training with a big dataset, but I didn't see any similar pattern in my tests.

You can already see that convolving galsim images with their associated PSF gives better results with the new code:

- first convolution code
![image](https://github.com/JonnyyTorres/Galsim_JAX/assets/30293694/923d7d34-ee5a-4124-a1a2-60e588e4bdf7)

- **new** convolution code
![image](https://github.com/JonnyyTorres/Galsim_JAX/assets/30293694/a6e4160d-e83a-4399-b3d3-c850d9a59952)

I commented the lines to register galaxies noise standard deviation to make faster experiments. I would be interested to see a full training with this configuration and make to complete dataset with the correct std in a second step.